### PR TITLE
Update Apache and Libre Office logos to infographic_debian image

### DIFF
--- a/debian/CHANGELOG
+++ b/debian/CHANGELOG
@@ -13,7 +13,7 @@
    - Added "The future is Open!";
    - Changed the license to CC by-sa 4.0;
    - Revised all type fonts used;
-   - Revised all supported archictetures with its additions and remotions;
+   - Revised all supported architectures with its additions and remotions;
    - Small space adjusts in 1993-1996;
    - Typo corrections for en-us - Thanks to Gijs Hillenius, Martin 
      Schuster, Brian Foley, Uwe Jugel;


### PR DESCRIPTION
This PR replaces the old Apache logo by the new one. You can see several versions at https://www.apache.org/foundation/press/kit/

I included the https://www.apache.org/foundation/press/kit/feather.svg file into debian/infographic_debian.svg.